### PR TITLE
Add multi role support to SetAufstellung

### DIFF
--- a/backend/endpoints/api/controller.ts
+++ b/backend/endpoints/api/controller.ts
@@ -65,7 +65,7 @@ async function setAufstellung(req: Request, authentication: Authentication): Pro
 			if (1 <= player.position && player.position <= 10) {
 
 				try {
-					await _element.setCompleteElement(aufstellung, Number(player.position), Number(player.classId), Number(player.roleId), Number(player.spielerId))
+					await _element.setCompleteElement(aufstellung, Number(player.position), Number(player.classId), player.roleId.toString(), Number(player.spielerId))
 				} catch (e) {
 					// Ignore, next element
 				}

--- a/backend/endpoints/aufstellungen/element.ts
+++ b/backend/endpoints/aufstellungen/element.ts
@@ -66,7 +66,7 @@ export async function setCompleteElement(
 	aufstellung: number,
 	position: number,
 	classId: number,
-	roleId: number,
+	roles: string,
 	playerId: number
 ): Promise<OkPacket> {
 	const stmt = `
@@ -75,7 +75,7 @@ export async function setCompleteElement(
 		ON DUPLICATE KEY UPDATE fk_class = ?, roles = ?, fk_spieler = ?
 	`;
 	try {
-		return await db.queryV(stmt, [aufstellung, position, classId, roleId, playerId, classId, roleId, playerId]);
+		return await db.queryV(stmt, [aufstellung, position, classId, roles, playerId, classId, roles, playerId]);
 	} catch (e) {
 		throw e;
 	}


### PR DESCRIPTION
The endpoint api/SetAfstelllung was not supporting the "new" multi
role feature, so it required an update.

Changed from conversion to number to string in the api/contoller.
Updated the parameter roleId of element/setCompleteElement by
changing the type to string and renaming it to roles as it better
fits the new purpose.

The parameter name of the external api endpoint was not changed to
preserve backwards comptibility.